### PR TITLE
update readme maven section

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,7 +59,7 @@ for the latest stable release:
 
     <dependency>
         <groupId>it.bitbl</groupId>
-        <artifactId>scala-faker_2.12.3</artifactId>
+        <artifactId>scala-faker_2.12</artifactId>
         <version>0.4</version>
     </dependency>
 
@@ -67,11 +67,11 @@ for snapshot:
 
     <dependency>
         <groupId>it.bitbl</groupId>
-        <artifactId>scala-faker_2.12.3</artifactId>
+        <artifactId>scala-faker_2.12</artifactId>
         <version>0.5-SNAPSHOT</version>
     </dependency>
 
-where `2.12.3` is your Scala version.
+where `2.12.x` is your Scala version.
 
 ### Credits
 


### PR DESCRIPTION
Scala jars are published without the minor version (ie _2.12 as opposed to _2.12.3)